### PR TITLE
update to sequelize 2.0.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var SequelizeStore = function (Session) {
 // for koa-sess
 SequelizeStore.prototype.get = function *(sid, parse) {
   try {
-    var data = yield this.Session.find({ id: sid });
+    var data = yield this.Session.find({ where: { id: sid } });
     if (data && data.id) {
       if (parse === false) return data.blob;
       return JSON.parse(data.blob);
@@ -40,7 +40,7 @@ SequelizeStore.prototype.set = SequelizeStore.prototype.save = function *(sid, b
       id: sid,
       blob: blob
     };
-    var affectedRows = yield this.Session.update(data, { id: sid });
+    var affectedRows = yield this.Session.update(data, { where: { id: sid } });
     if (affectedRows == 0) { // no affected rows => assume the record not exists
       yield this.Session.build(data).save();
     }
@@ -54,7 +54,7 @@ SequelizeStore.prototype.set = SequelizeStore.prototype.save = function *(sid, b
  */
 SequelizeStore.prototype.destroy = SequelizeStore.prototype.remove = function *(sid) {
   try {
-    yield this.Session.destroy({ id: sid });
+    yield this.Session.destroy({ where: { id: sid } });
   } catch (err) {
     console.error(err.stack);
   }
@@ -68,7 +68,7 @@ exports.create = function (sequelize, options) {
   options.expires = options.expires || 60 * 60 * 24 * 14; // 2 weeks
   options.table = options.table || 'sessions';
   options.model = options.model || 'Session';  // model name
-  
+
   var Session = sequelize.import('koa-session-sequelize-' + options.model, function (sequelize, DataTypes) {
     return sequelize.define(options.model, {
         id: { type: DataTypes.STRING, allowNull: false, autoIncrement:false, primaryKey: true },
@@ -77,6 +77,6 @@ exports.create = function (sequelize, options) {
         tableName: options.table
     });
   });
-  
+
   return new SequelizeStore(Session);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-session-sequelize",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Sequelize based storage layer for Koa session middleware",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "email": "gzhang.82@gmail.com"
   },
   "license": "MIT",
-  "dependencies": {
-    "koa-route": "^2.1.0",
-    "sequelize": "^1.7.9"
+  "peerDependencies": {
+    "sequelize": "^2.0.5"
   },
   "devDependencies": {
     "supertest": "^0.13.0",


### PR DESCRIPTION
The proposed changes make koa-session-sequelize compatible with new sequelize API by wrapping query objects into {where: } structures.
